### PR TITLE
Chore/fix import ordering

### DIFF
--- a/cmd/webhook/main.go
+++ b/cmd/webhook/main.go
@@ -3,16 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"github.com/opentracing/opentracing-go"
-	"github.com/sirupsen/logrus"
-	"github.com/urfave/cli"
-	"github.com/vastness-io/queues/pkg/queue"
-	toolkit "github.com/vastness-io/toolkit/pkg/grpc"
-	"github.com/vastness-io/vcs-webhook-svc/webhook"
-	"github.com/vastness-io/vcs-webhook/pkg/route"
-	"github.com/vastness-io/vcs-webhook/pkg/service"
-	"github.com/vastness-io/vcs-webhook/pkg/transport"
-	"google.golang.org/grpc"
 	"net"
 	"net/http"
 	"os"
@@ -20,6 +10,18 @@ import (
 	"strconv"
 	"syscall"
 	"time"
+
+	"github.com/opentracing/opentracing-go"
+	"github.com/sirupsen/logrus"
+	"github.com/urfave/cli"
+	"github.com/vastness-io/queues/pkg/queue"
+	"google.golang.org/grpc"
+
+	toolkit "github.com/vastness-io/toolkit/pkg/grpc"
+	"github.com/vastness-io/vcs-webhook-svc/webhook"
+	"github.com/vastness-io/vcs-webhook/pkg/route"
+	"github.com/vastness-io/vcs-webhook/pkg/service"
+	"github.com/vastness-io/vcs-webhook/pkg/transport"
 )
 
 const (

--- a/pkg/route/bitbucketserver.go
+++ b/pkg/route/bitbucketserver.go
@@ -3,13 +3,15 @@ package route
 import (
 	"context"
 	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/negroni"
+
 	toolkit_http "github.com/vastness-io/toolkit/pkg/http"
 	"github.com/vastness-io/vcs-webhook-svc/webhook/bitbucketserver"
 	"github.com/vastness-io/vcs-webhook/pkg/service"
-	"io/ioutil"
-	"net/http"
 )
 
 // NewBitbucketServerOnPushRouteHandler creates a "Route" handler, providing encoding/decoding, error and service level handling and wrapping in route specific middleware.

--- a/pkg/route/github.go
+++ b/pkg/route/github.go
@@ -3,13 +3,15 @@ package route
 import (
 	"context"
 	"encoding/json"
+	"io/ioutil"
+	"net/http"
+
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/negroni"
+
 	toolkit_http "github.com/vastness-io/toolkit/pkg/http"
 	"github.com/vastness-io/vcs-webhook-svc/webhook/github"
 	"github.com/vastness-io/vcs-webhook/pkg/service"
-	"io/ioutil"
-	"net/http"
 )
 
 // NewGithubOnPushRouteHandler creates a "Route" handler, providing encoding/decoding, error and service level handling and wrapping in route specific middleware.

--- a/pkg/route/middleware_github.go
+++ b/pkg/route/middleware_github.go
@@ -17,7 +17,7 @@ func ValidGithubWebhookRequest() func(http.ResponseWriter, *http.Request, http.H
 	return ValidGithubWebhookRequestSecure("")
 }
 
-// ValidGithubWebhookRequest is Middleware which verifies the request is from Github and with the correct secret.
+// ValidGithubWebhookRequestSecure is Middleware which verifies the request is from Github and with the correct secret.
 func ValidGithubWebhookRequestSecure(secret string) func(http.ResponseWriter, *http.Request, http.HandlerFunc) {
 	return func(w http.ResponseWriter, r *http.Request, next http.HandlerFunc) {
 

--- a/pkg/service/bitbucketserver.go
+++ b/pkg/service/bitbucketserver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/afex/hystrix-go/hystrix"
+
 	"github.com/vastness-io/queues/pkg/core"
 	"github.com/vastness-io/vcs-webhook-svc/webhook"
 	"github.com/vastness-io/vcs-webhook-svc/webhook/bitbucketserver"

--- a/pkg/service/bitbucketserver_converter.go
+++ b/pkg/service/bitbucketserver_converter.go
@@ -2,9 +2,10 @@ package service
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/vastness-io/vcs-webhook-svc/webhook"
 	"github.com/vastness-io/vcs-webhook-svc/webhook/bitbucketserver"
-	"time"
 )
 
 const (

--- a/pkg/service/conversion_test.go
+++ b/pkg/service/conversion_test.go
@@ -2,11 +2,12 @@ package service
 
 import (
 	"encoding/json"
+	"reflect"
+	"testing"
+
 	"github.com/vastness-io/vcs-webhook-svc/webhook"
 	"github.com/vastness-io/vcs-webhook-svc/webhook/bitbucketserver"
 	"github.com/vastness-io/vcs-webhook-svc/webhook/github"
-	"reflect"
-	"testing"
 )
 
 type convertTestHelper = struct {

--- a/pkg/service/github.go
+++ b/pkg/service/github.go
@@ -2,7 +2,9 @@ package service
 
 import (
 	"context"
+
 	"github.com/afex/hystrix-go/hystrix"
+
 	"github.com/vastness-io/queues/pkg/core"
 	"github.com/vastness-io/vcs-webhook-svc/webhook"
 	"github.com/vastness-io/vcs-webhook-svc/webhook/github"

--- a/pkg/service/github_converter.go
+++ b/pkg/service/github_converter.go
@@ -1,9 +1,10 @@
 package service
 
 import (
+	"time"
+
 	"github.com/vastness-io/vcs-webhook-svc/webhook"
 	"github.com/vastness-io/vcs-webhook-svc/webhook/github"
-	"time"
 )
 
 // MapPostWebhookToVcsPushEvent converts a Github push event message to a PushEvent
@@ -152,8 +153,6 @@ func MapGithubPushEventToVcsPushEvent(from *github.PushEvent) *vcs.VcsPushEvent 
 		out.Repository = &outRepository
 
 	}
-
-
 
 	out.Created = from.Created
 	out.Deleted = from.Deleted

--- a/pkg/service/github_converter.go
+++ b/pkg/service/github_converter.go
@@ -7,7 +7,7 @@ import (
 	"github.com/vastness-io/vcs-webhook-svc/webhook/github"
 )
 
-// MapPostWebhookToVcsPushEvent converts a Github push event message to a PushEvent
+// MapGithubPushEventToVcsPushEvent converts a Github push event message to a PushEvent
 func MapGithubPushEventToVcsPushEvent(from *github.PushEvent) *vcs.VcsPushEvent {
 	if from == nil {
 		return nil

--- a/pkg/service/service_test.go
+++ b/pkg/service/service_test.go
@@ -2,36 +2,37 @@ package service
 
 import (
 	"context"
+	"reflect"
+	"testing"
+	"time"
+
 	"github.com/golang/mock/gomock"
 	"github.com/golang/protobuf/ptypes/empty"
+
 	"github.com/vastness-io/queues/pkg/core"
 	"github.com/vastness-io/queues/pkg/queue"
 	"github.com/vastness-io/vcs-webhook-svc/mock/webhook"
 	"github.com/vastness-io/vcs-webhook-svc/webhook"
 	"github.com/vastness-io/vcs-webhook-svc/webhook/bitbucketserver"
 	"github.com/vastness-io/vcs-webhook-svc/webhook/github"
-	"reflect"
-	"testing"
-	"time"
 )
 
 type serviceTestHelper = struct {
-	ctrl *gomock.Controller
+	ctrl     *gomock.Controller
 	queue    core.BlockingQueue
-	service Service
+	service  Service
 	expected interface{}
 	notifyCh chan struct{}
 }
 
 func newTestHelper(t *testing.T, service Service, expected interface{}) serviceTestHelper {
 	return serviceTestHelper{
-		ctrl: gomock.NewController(t),
-		queue: queue.NewFIFOQueue(0, time.Millisecond*250),
-		service: service,
+		ctrl:     gomock.NewController(t),
+		queue:    queue.NewFIFOQueue(0, time.Millisecond*250),
+		service:  service,
 		expected: expected,
 	}
 }
-
 
 func TestWorkOnQueueEmptyQueue(t *testing.T) {
 	type testHelper struct {

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+
 	"github.com/sirupsen/logrus"
 )
 

--- a/pkg/transport/http.go
+++ b/pkg/transport/http.go
@@ -1,9 +1,10 @@
 package transport
 
 import (
+	"net/http"
+
 	toolkit_http "github.com/vastness-io/toolkit/pkg/http"
 	"github.com/vastness-io/vcs-webhook/pkg/route"
-	"net/http"
 )
 
 const (

--- a/pkg/transport/http_test.go
+++ b/pkg/transport/http_test.go
@@ -3,16 +3,17 @@ package transport
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/vastness-io/queues/pkg/queue"
-	"github.com/vastness-io/vcs-webhook-svc/webhook/bitbucketserver"
-	"github.com/vastness-io/vcs-webhook-svc/webhook/github"
-	"github.com/vastness-io/vcs-webhook/pkg/route"
-	"github.com/vastness-io/vcs-webhook/pkg/service"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
+
+	"github.com/vastness-io/queues/pkg/queue"
+	"github.com/vastness-io/vcs-webhook-svc/webhook/bitbucketserver"
+	"github.com/vastness-io/vcs-webhook-svc/webhook/github"
+	"github.com/vastness-io/vcs-webhook/pkg/route"
+	"github.com/vastness-io/vcs-webhook/pkg/service"
 )
 
 func TestGithubOnPushRoute(t *testing.T) {


### PR DESCRIPTION
This will improve a bit the ordering of imports, making them easier to see

Usually it's:
```
Import (
    Std Lib

    3rd Party

    Current project
)
```

I've also fixed some naming in the function docs.